### PR TITLE
✨ AnnDataAccessor for backed access to cloud AnnData attributes

### DIFF
--- a/docs/guide/stream.ipynb
+++ b/docs/guide/stream.ipynb
@@ -158,42 +158,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can do the same with a zarr object:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "file = ln.add(ln.File(\"s3://lamindb-ci/lndb-storage/pbmc68k.zarr\"))\n",
-    "print(file.backed().obs.head())\n",
-    "adata_subset = file.stream(subset_obs=subset_obs)\n",
-    "adata_subset.obs.cell_type.value_counts()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "It is also possible to access AnnData objects' attributes and subset them directly through `file.backed()` withouth loading the full objects into memory:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "adata = file.backed()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that this is an AnnDataAccessor object, not an AnnData object"
    ]
   },
   {
@@ -206,12 +171,33 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the object above is an AnnDataAccessor object, not an AnnData object"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check the reference to `.X`:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "adata.X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get a subset of the object, attributes are loaded only on explicit access:"
    ]
   },
   {
@@ -241,6 +227,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "adata_subset.obs.cell_type.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can do the same with a zarr object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file = ln.add(ln.File(\"s3://lamindb-ci/lndb-storage/pbmc68k.zarr\"))\n",
+    "print(file.backed().obs.head())\n",
+    "adata_subset = file.stream(subset_obs=subset_obs)\n",
     "adata_subset.obs.cell_type.value_counts()"
    ]
   }

--- a/docs/guide/stream.ipynb
+++ b/docs/guide/stream.ipynb
@@ -172,6 +172,77 @@
     "adata_subset = file.stream(subset_obs=subset_obs)\n",
     "adata_subset.obs.cell_type.value_counts()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is also possible to access AnnData objects' attributes and subset them directly through `file.backed()` withouth loading the full objects into memory:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata = file.backed()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that this is an AnnDataAccessor object, not an AnnData object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.X"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subset_obs = adata.obs.cell_type.isin([\"Dendritic cells\", \"CD14+ Monocytes\"]) & (\n",
+    "    adata.obs.percent_mito <= 0.05\n",
+    ")\n",
+    "adata_subset = adata[subset_obs]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata_subset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata_subset.obs.cell_type.value_counts()"
+   ]
   }
  ],
  "metadata": {
@@ -190,7 +261,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.12"
   },
   "nbproject": {
    "id": "YVUCtH4GfQOy",

--- a/docs/guide/stream.ipynb
+++ b/docs/guide/stream.ipynb
@@ -206,10 +206,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "subset_obs = adata.obs.cell_type.isin([\"Dendritic cells\", \"CD14+ Monocytes\"]) & (\n",
+    "obs_idx = adata.obs.cell_type.isin([\"Dendritic cells\", \"CD14+ Monocytes\"]) & (\n",
     "    adata.obs.percent_mito <= 0.05\n",
     ")\n",
-    "adata_subset = adata[subset_obs]"
+    "adata_subset = adata[obs_idx]"
    ]
   },
   {

--- a/lndb_storage/object/_anndata_accessor.py
+++ b/lndb_storage/object/_anndata_accessor.py
@@ -38,6 +38,9 @@ class _MapAccessor:
         else:
             return read_elem_partial(self.elem[key], indices=self.indices)
 
+    def keys(self):
+        return self.elem.keys()
+
 
 class AnnDataAccessor:
     def __init__(self, file: File):

--- a/lndb_storage/object/_anndata_accessor.py
+++ b/lndb_storage/object/_anndata_accessor.py
@@ -243,7 +243,11 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
 
         if file.suffix == ".h5ad":
             self._conn = fs.open(file_path_str, mode="rb")
-            self.storage = h5py.File(self._conn, mode="r")
+            try:
+                self.storage = h5py.File(self._conn, mode="r")
+            except Exception as e:
+                self._conn.close()
+                raise e
         elif file.suffix in (".zarr", ".zrad"):
             self._conn = None
             mapper = fs.get_mapper(file_path_str, check=True)

--- a/lndb_storage/object/_anndata_accessor.py
+++ b/lndb_storage/object/_anndata_accessor.py
@@ -222,9 +222,9 @@ class AnnDataRawAccessor(AnnDataAccessorSubset):
             if isinstance(var_raw, (h5py.Dataset, zarr.Array)):
                 attrs_keys["var"] = list(var_raw.dtype.fields.keys())
             else:
-                attrs_keys["var"] = list(var_raw.keys())
+                attrs_keys["var"] = [key for key in var_raw]
             if "varm" in storage_raw:
-                varm_keys_raw = list(storage_raw["varm"].keys())
+                varm_keys_raw = [key for key in storage_raw["varm"]]
                 if len(varm_keys_raw) > 0:
                     attrs_keys["varm"] = varm_keys_raw
 
@@ -271,7 +271,9 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
             ):
                 keys = list(attr_obj.dtype.fields.keys())
             else:
-                keys = list(attr_obj.keys())
+                # for some reason list(attr_obj.keys()) is very slow for zarr
+                # maybe directly get keys from the underlying mapper
+                keys = [key for key in attr_obj]
             if len(keys) > 0:
                 self._attrs_keys[attr] = keys
 

--- a/lndb_storage/object/_anndata_accessor.py
+++ b/lndb_storage/object/_anndata_accessor.py
@@ -62,10 +62,6 @@ class AnnDataAccessor:
             self._conn.close()
 
     @cached_property
-    def X(self):
-        return _try_backed_full(self.storage["X"])
-
-    @cached_property
     def obs(self) -> pd.DataFrame:
         return read_dataframe(self.storage["obs"])
 
@@ -76,6 +72,10 @@ class AnnDataAccessor:
     @cached_property
     def uns(self):
         return read_elem(self.storage["uns"])
+
+    @property
+    def X(self):
+        return _try_backed_full(self.storage["X"])
 
     @property
     def obsm(self):

--- a/lndb_storage/object/_anndata_accessor.py
+++ b/lndb_storage/object/_anndata_accessor.py
@@ -45,7 +45,13 @@ class _MapAccessor:
             return read_elem_partial(self.elem[key], indices=self.indices)
 
     def keys(self):
-        return self.elem.keys()
+        return list(self.elem.keys())
+
+    def __repr__(self):
+        """Description of the _MapAccessor object."""
+        descr = f"Accessor for the AnnData attribute {self.name}"
+        descr += f"\n  with keys: {self.keys()}"
+        return descr
 
 
 class _AnnDataAttrsMixin:
@@ -170,6 +176,14 @@ class AnnDataAccessorSubset(_AnnDataAttrsMixin):
             self._ref_shape,
         )
 
+    def __repr__(self):
+        """Description of the object."""
+        n_obs, n_vars = self.shape
+        descr = f"{type(self).__name__} object with n_obs × n_vars = {n_obs} × {n_vars}"
+        for attr, keys in self._attrs_keys.items():
+            descr += f"\n  {attr}: {keys}"
+        return descr
+
     @cached_property
     def raw(self):
         if "raw" not in self._attrs_keys:
@@ -282,7 +296,7 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
         descr = f"AnnDataAccessor object with n_obs × n_vars = {n_obs} × {n_vars}"
         descr += f"\n  constructed for the AnnData object {self._name}"
         for attr, keys in self._attrs_keys.items():
-            descr += f"\n    {attr}: {str(keys)}"
+            descr += f"\n    {attr}: {keys}"
         return descr
 
     @cached_property

--- a/lndb_storage/object/_anndata_accessor.py
+++ b/lndb_storage/object/_anndata_accessor.py
@@ -6,8 +6,8 @@ import pandas as pd
 import zarr
 from anndata._core.sparse_dataset import SparseDataset
 from anndata._io.h5ad import read_dataframe
-from anndata._io.spec.registry import get_spec
-from anndata._io.specs.registry import read_elem, read_elem_partial
+from anndata._io.specs.methods import read_indices
+from anndata._io.specs.registry import get_spec, read_elem, read_elem_partial
 from lndb.dev.upath import infer_filesystem as _infer_filesystem
 from lnschema_core import File
 from lnschema_core.dev._storage import filepath_from_file
@@ -125,6 +125,8 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
             raise ValueError(
                 f"file should have .h5ad, .zarr or .zrad suffix, not {file.suffix}."
             )
+
+        self._obs_names, self._var_names = read_indices(self.storage)
 
     def __del__(self):
         """Closes the connection."""

--- a/lndb_storage/object/_anndata_accessor.py
+++ b/lndb_storage/object/_anndata_accessor.py
@@ -1,0 +1,90 @@
+from functools import cached_property
+
+import h5py
+import pandas as pd
+import zarr
+from anndata._core.sparse_dataset import SparseDataset
+from anndata._io.h5ad import read_dataframe
+from anndata._io.spec.registry import get_spec
+from anndata._io.specs.registry import read_elem, read_elem_partial
+from lndb.dev.upath import infer_filesystem as _infer_filesystem
+from lnschema_core import File
+from lnschema_core.dev._storage import filepath_from_file
+
+
+def _try_backed_full(elem):
+    # think what to do for compatibility with old var and obs
+    if isinstance(elem, (h5py.Dataset, zarr.Dataset)):
+        return elem
+
+    if isinstance(elem, (h5py.Group, zarr.Group)):
+        encoding_type = get_spec(elem)
+        if encoding_type in ("csr_matrix", "csc_matrix"):
+            return SparseDataset(elem)
+        if "h5sparse_format" in elem.attrs:
+            return SparseDataset(elem)
+
+    return read_elem(elem)
+
+
+class _MapAccessor:
+    def __init__(self, elem, indices=None):
+        self.elem = elem
+        self.indices = indices
+
+    def __getitem__(self, key):
+        if self.indices is None:
+            return _try_backed_full(self.elem[key])
+        else:
+            return read_elem_partial(self.elem[key], indices=self.indices)
+
+
+class AnnDataAccessor:
+    def __init__(self, file: File):
+        fs, file_path_str = _infer_filesystem(filepath_from_file(file))
+
+        if file.suffix == ".h5ad":
+            self._conn = fs.open(file_path_str, mode="rb")
+            self.storage = h5py.File(self._conn, mode="r")
+        elif file.suffix in (".zarr", ".zrad"):
+            self._conn = None
+            mapper = fs.get_mapper(file_path_str, check=True)
+            self.storage = zarr.open(mapper, mode="r")
+        else:
+            raise ValueError(
+                f"file should have .h5ad, .zarr or .zrad suffix, not {file.suffix}."
+            )
+
+    def __del__(self):
+        """Closes the connection."""
+        if self._conn is not None:
+            self.storage.close()
+            self._conn.close()
+
+    @cached_property
+    def X(self):
+        return _try_backed_full(self.storage["X"])
+
+    @cached_property
+    def obs(self) -> pd.DataFrame:
+        return read_dataframe(self.storage["obs"])
+
+    @cached_property
+    def var(self) -> pd.DataFrame:
+        return read_dataframe(self.storage["var"])
+
+    @cached_property
+    def uns(self):
+        return read_elem(self.storage["uns"])
+
+    @property
+    def obsm(self):
+        return _MapAccessor(self.storage["obsm"])
+
+    @property
+    def varm(self):
+        return _MapAccessor(self.storage["varm"])
+
+    @property
+    def layers(self):
+        return _MapAccessor(self.storage["layers"])

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,9 +15,9 @@ def lint(session: nox.Session) -> None:
 def build(session):
     login_testuser1(session)
     session.install(".[dev,test]")
-    response = requests.get("https://github.com/laminlabs/lamindb/tree/cloud")
+    response = requests.get("https://github.com/laminlabs/lamindb/tree/adata_access")
     if response.status_code < 400:
-        session.install("git+https://github.com/laminlabs/lamindb@cloud")
+        session.install("git+https://github.com/laminlabs/lamindb@adata_access")
     else:
         session.install("git+https://github.com/laminlabs/lamindb")
     run_pytest(session)


### PR DESCRIPTION
Here i am working on creating the full scale backed access (with and without subset) to AnnData objects in the cloud.
This is in progress.

@falexwolf 
I would prefer to rename `CloudAnnData` to `AnnDataAccessor`, because i believe `CloudAnnData` could be confusing for users, they will expect it to be a real `AnnData` object due to the name and it is just not. Do you agree?