### PR TITLE
➖ Update fsspec and move s3 and gs dependencies to extras 

### DIFF
--- a/docs/guide/upload.ipynb
+++ b/docs/guide/upload.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "dd6bf8d1-ba40-4054-9f62-a402588f7a95",
    "metadata": {},
@@ -40,7 +39,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "bb95abe7",
    "metadata": {},
@@ -49,7 +47,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b11215af-bb7f-4932-83ee-8f46f5583ed8",
    "metadata": {},
@@ -68,7 +65,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "7af3d05d-8dc3-455d-be1b-83e798621051",
    "metadata": {},
@@ -97,7 +93,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "622b8012-6a94-4a41-8a6b-4c178ed4cfa6",
    "metadata": {},
@@ -106,7 +101,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "8138a887-2de8-4ad9-ad8b-63324263fb7d",
    "metadata": {},
@@ -145,7 +139,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ff0e34cd-8ebd-4196-a7bd-a667b2a360a1",
    "metadata": {},
@@ -167,7 +160,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c552af90-b4b3-4465-aaec-662949d480b3",
    "metadata": {},
@@ -176,7 +168,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6ac16f8b-3952-469b-9b6c-3a78c096467c",
    "metadata": {},
@@ -215,7 +206,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "8bd5da59-c616-4e49-9f02-f4814c19032f",
    "metadata": {},
@@ -237,7 +227,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "06a91d99-d204-4ec2-b567-960a2aaad38d",
    "metadata": {
@@ -248,7 +237,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f760cba0-38a0-4be2-8854-d1f17689de05",
    "metadata": {},
@@ -279,7 +267,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "bcb399bd-8c13-424a-bbb7-d6bb7cb1f5e7",
    "metadata": {},
@@ -299,7 +286,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "64550c3f",
    "metadata": {},
@@ -308,50 +294,6 @@
    ]
   },
   {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "08c15a44",
-   "metadata": {},
-   "source": [
-    "Let's configure an instance with cloud storage (s3):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c78670c8",
-   "metadata": {
-    "tags": [
-     "hide-cell"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "assert ln.setup.settings.user.handle == \"testuser1\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b2a202c8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln.setup.init(storage=\"s3://lamindb-ci\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bf8fa70b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln.setup.settings.storage.root"
-   ]
-  },
-  {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "62486d5f",
    "metadata": {},
@@ -380,7 +322,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "fcf85251",
    "metadata": {},
@@ -441,7 +382,7 @@
    },
    "outputs": [],
    "source": [
-    "# Clean the test instance\n",
+    "# Delete the file record\n",
     "ln.delete(file, delete_data_from_storage=False)"
    ]
   }
@@ -462,7 +403,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.12"
   },
   "nbproject": {
    "id": "psZgub4FOmzS",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 dynamic = ["version", "description"]
 dependencies = [
     "lnschema_core",
-    "lndb>=0.45a3",
+    "lndb>=0.45a4",
     "lamin_logger>=0.3.0",
     "nbproject",
     "readfcs",
@@ -27,12 +27,11 @@ dependencies = [
 Home = "https://github.com/laminlabs/lndb-storage"
 
 [project.optional-dependencies]
-s3 = [
-    "boto3==1.26.76", # for aiobotocore inside s3fs, to fix deps resolution
+aws = [
     "botocore==1.29.76", # for aiobotocore inside s3fs, to fix deps resolution
     "fsspec[s3]==2023.5.0"
 ]
-gs = [
+gcp = [
     "fsspec[gs]==2023.5.0"
 ]
 dev = [
@@ -44,9 +43,9 @@ test = [
     "pytest-cov",
     "scanpy",
     "pyarrow",
-    "lndb>=0.45a3",
+    "lndb>=0.45a4",
     "nbproject-test",
-    "lndb_storage[s3,gs]"
+    "lndb_storage[aws,gcp]"
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,7 @@ dependencies = [
     "python-dateutil",
     "zarr",
     "anndata>=0.9.1",
-    "boto3==1.24.59", # for aiobotocore inside s3fs, to fix deps resolution
-    "botocore==1.27.59", # for aiobotocore inside s3fs, to fix deps resolution
-    "fsspec==2023.1.0",
-    "s3fs==2023.1.0",
-    "gcsfs==2023.1.0",
+    "fsspec",
     "universal_pathlib",
     "scipy",
     "pandas",
@@ -31,6 +27,14 @@ dependencies = [
 Home = "https://github.com/laminlabs/lndb-storage"
 
 [project.optional-dependencies]
+s3 = [
+    "boto3==1.26.76", # for aiobotocore inside s3fs, to fix deps resolution
+    "botocore==1.29.76", # for aiobotocore inside s3fs, to fix deps resolution
+    "fsspec[s3]==2023.5.0"
+]
+gs = [
+    "fsspec[gs]==2023.5.0"
+]
 dev = [
     "pre-commit",
     "nox",
@@ -42,6 +46,7 @@ test = [
     "pyarrow",
     "lndb>=0.41rc1",
     "nbproject-test",
+    "lndb_storage[s3,gs]"
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 dynamic = ["version", "description"]
 dependencies = [
     "lnschema_core",
-    "lndb>=0.41.0",
+    "lndb>=0.45a3",
     "lamin_logger>=0.3.0",
     "nbproject",
     "readfcs",
@@ -44,7 +44,7 @@ test = [
     "pytest-cov",
     "scanpy",
     "pyarrow",
-    "lndb>=0.41rc1",
+    "lndb>=0.45a3",
     "nbproject-test",
     "lndb_storage[s3,gs]"
 ]


### PR DESCRIPTION
- https://github.com/laminlabs/lndb-storage/issues/37

In principle we can remove the pin on boto3 when `lnhub-rest==0.9.6` is released and propagated.